### PR TITLE
URLSessionInstrumentation crash ALPH-2195

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,11 @@ Release Date: April 8, 2025
 
 Fix issue related to CustomDomainUrl was removed. 
 Native SDK upgraded to 1.0.18
+
+## 0.0.6
+Version 0.0.6
+Release Date: April 24, 2025
+
+Fix Crash related to URLSessionInstrumentation.
+Navigation instument was removed form CoralogixOptions 
+Native SDK upgraded to 1.0.20

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,8 +1,10 @@
 PODS:
-  - Coralogix (1.0.18):
+  - Coralogix (1.0.20):
+    - CoralogixInternal
     - PLCrashReporter (~> 1.11.1)
-  - cx_flutter_plugin (0.0.5):
-    - Coralogix (~> 1.0.18)
+  - CoralogixInternal (1.0.20)
+  - cx_flutter_plugin (0.0.6):
+    - Coralogix (~> 1.0.20)
     - Flutter
   - Flutter (1.0.0)
   - integration_test (0.0.1):
@@ -17,6 +19,7 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - Coralogix
+    - CoralogixInternal
     - PLCrashReporter
 
 EXTERNAL SOURCES:
@@ -28,8 +31,9 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
 
 SPEC CHECKSUMS:
-  Coralogix: a718ba8235d68a3002977bd46b4354bd3113ab23
-  cx_flutter_plugin: 5f37de4c063dffed7bade9336d7ff55da886ea69
+  Coralogix: b3420f183705a965e3c5b5d0657990d8fdbc948b
+  CoralogixInternal: b6833e98ae7652163566fec626d9f1a57f0ade5f
+  cx_flutter_plugin: 4aeb8edb41e228d7c18e75c010aa31e19cb8df65
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: d5929033778cc4991a187e4e1a85396fa4f59b3a
   PLCrashReporter: 97cef386c199b54662e744d1a62c19f7bfe08e90

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -67,7 +67,6 @@ class _MyAppState extends State<MyApp> {
                           CXInstrumentationType.errors.value: true,
                           CXInstrumentationType.lifeCycle.value: true,
                           CXInstrumentationType.mobileVitals.value: true,
-                          CXInstrumentationType.navigation.value: true,
                           CXInstrumentationType.network.value: true,
                           CXInstrumentationType.userActions.value: true},
       collectIPData: true,

--- a/ios/Classes/CxFlutterPlugin.swift
+++ b/ios/Classes/CxFlutterPlugin.swift
@@ -160,8 +160,6 @@ public class CxFlutterPlugin: NSObject, FlutterPlugin {
         switch string {
         case "mobileVitals":
             return .mobileVitals
-        case "navigation":
-            return .navigation
         case "custom":
             return .custom
         case "errors":

--- a/ios/cx_flutter_plugin.podspec
+++ b/ios/cx_flutter_plugin.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'cx_flutter_plugin'
-  s.version          = '0.0.5'
+  s.version          = '0.0.6'
   s.summary          = 'Coralogix Flutter plugin.'
   s.description      = <<-DESC
 Coralogix Flutter plugin.
@@ -20,7 +20,7 @@ Coralogix Flutter plugin.
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
 
-  s.dependency 'Coralogix', '~> 1.0.18'
+  s.dependency 'Coralogix', '~> 1.0.20'
 
   s.ios.deployment_target = '13.0'
   s.static_framework = true

--- a/lib/cx_instrumentation_type.dart
+++ b/lib/cx_instrumentation_type.dart
@@ -1,7 +1,6 @@
 
 enum CXInstrumentationType {
   mobileVitals('mobileVitals'),
-  navigation('navigation'),
   custom('custom'),
   errors('errors'),
   network('network'),

--- a/publish_plugin.sh
+++ b/publish_plugin.sh
@@ -45,7 +45,7 @@ if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
 fi
 
 echo "📤 Publishing to pub.dev..."
-flutter pub publish
+flutter pub publish --force
 
 echo "🔖 Tagging release with v$PLUGIN_VERSION..."
 git tag "v$PLUGIN_VERSION"


### PR DESCRIPTION
fix: update the native sdk 1.0.20 which fix the URLSessionInstrumentation crash
fix: remove the navigation from coralogixOptions