### PR TITLE
feat: Update Android SDK to 2.4.3 and enhance plugin functionality

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,8 +51,8 @@ android {
     }
 
     dependencies {
-        implementation("com.coralogix:android-sdk:2.1.1")
-        coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.3")
+        implementation("com.coralogix:android-sdk:2.4.3")
+        coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
         testImplementation("org.jetbrains.kotlin:kotlin-test")
         testImplementation("org.mockito:mockito-core:5.12.0")
     }

--- a/android/src/main/kotlin/com/coralogix/flutter/plugin/CxFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/coralogix/flutter/plugin/CxFlutterPlugin.kt
@@ -36,6 +36,10 @@ class CxFlutterPlugin: FlutterPlugin, MethodCallHandler {
             REPORT_ERROR -> pluginManager.reportError(call, result)
             SET_VIEW -> pluginManager.setView(call, result)
             SHUTDOWN -> pluginManager.shutdown(result)
+            GET_LABELS -> pluginManager.getLabels(result)
+            IS_INITIALIZED -> pluginManager.isInitialized(result)
+            GET_SESSION_ID -> pluginManager.getSessionId(result)
+            SET_APPLICATION_CONTEXT -> pluginManager.setApplicationContext(call, result)
             else -> result.notImplemented()
         }
     }
@@ -55,5 +59,9 @@ class CxFlutterPlugin: FlutterPlugin, MethodCallHandler {
         private const val REPORT_ERROR = "reportError"
         private const val SET_VIEW = "setView"
         private const val SHUTDOWN = "shutdown"
+        private const val GET_LABELS = "getLabels"
+        private const val IS_INITIALIZED = "isInitialized"
+        private const val GET_SESSION_ID = "getSessionId"
+        private const val SET_APPLICATION_CONTEXT = "setApplicationContext"
     }
 }

--- a/android/src/main/kotlin/com/coralogix/flutter/plugin/manager/FlutterPluginManager.kt
+++ b/android/src/main/kotlin/com/coralogix/flutter/plugin/manager/FlutterPluginManager.kt
@@ -61,7 +61,7 @@ internal class FlutterPluginManager(private val application: Application) : IFlu
             collectIPData = optionsDetails["collectIPData"] as? Boolean ?: true,
             sessionSampleRate = optionsDetails["sdkSampler"] as? Int ?: 100,
             fpsSamplingSeconds = optionsDetails["mobileVitalsFPSSamplingRate"] as? Long ?: 300,
-            customDomainUrl = optionsDetails["customDomainUrl"] as? String,
+            proxyUrl = optionsDetails["proxyUrl"] as? String,
             debug = optionsDetails["debug"] as? Boolean ?: false
         )
 
@@ -177,6 +177,36 @@ internal class FlutterPluginManager(private val application: Application) : IFlu
 
     override fun shutdown(result: MethodChannel.Result) {
         CoralogixRum.shutdown()
+        result.success()
+    }
+
+    override fun getLabels(result: MethodChannel.Result) {
+        val labels = CoralogixRum.getLabels()
+        result.success(labels)
+    }
+
+    override fun isInitialized(result: MethodChannel.Result) {
+        val isInitialized = CoralogixRum.isInitialized()
+        result.success(isInitialized)
+    }
+
+    override fun getSessionId(result: MethodChannel.Result) {
+        val sessionId = CoralogixRum.getSessionId()
+        result.success(sessionId)
+    }
+
+    override fun setApplicationContext(call: MethodCall, result: MethodChannel.Result) {
+        val arguments = call.arguments as? Map<*, *>
+        if (arguments == null || arguments.isEmpty()) {
+            result.invalidArgumentsError()
+            return
+        }
+
+        val applicationContextDetails = arguments.toStringMap()
+        val applicationName = applicationContextDetails["applicationName"] ?: ""
+        val applicationVersion = applicationContextDetails["applicationVersion"] ?: ""
+
+        CoralogixRum.setApplicationContext(applicationName, applicationVersion)
         result.success()
     }
 

--- a/android/src/main/kotlin/com/coralogix/flutter/plugin/manager/IFlutterPluginManager.kt
+++ b/android/src/main/kotlin/com/coralogix/flutter/plugin/manager/IFlutterPluginManager.kt
@@ -12,4 +12,8 @@ internal interface IFlutterPluginManager {
     fun reportError(call: MethodCall, result: Result)
     fun setView(call: MethodCall, result: Result)
     fun shutdown(result: Result)
+    fun getLabels(result: Result)
+    fun isInitialized(result: Result)
+    fun getSessionId(result: Result)
+    fun setApplicationContext(call: MethodCall, result: Result)
 }

--- a/android/src/main/kotlin/com/coralogix/flutter/plugin/mappers/CoralogixDomainMapper.kt
+++ b/android/src/main/kotlin/com/coralogix/flutter/plugin/mappers/CoralogixDomainMapper.kt
@@ -12,6 +12,7 @@ object CoralogixDomainMapper : IMapper<String, CoralogixDomain?> {
             CoralogixDomain.EU2.url -> CoralogixDomain.EU2
             CoralogixDomain.US1.url -> CoralogixDomain.US1
             CoralogixDomain.US2.url -> CoralogixDomain.US2
+            CoralogixDomain.STAGING.url -> CoralogixDomain.STAGING
             else -> null
         }
     }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -59,7 +59,7 @@ android {
     }
 
     dependencies {
-        coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.3")
+        coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
     }
 }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -47,7 +47,7 @@ class _MyAppState extends State<MyApp> {
       userMetadata: {'role': 'admin'},
     );
 
-    var coralogixDomain = CXDomain.eu2;
+    var coralogixDomain = CXDomain.staging;
 
     var options = CXExporterOptions(
       coralogixDomain: coralogixDomain,
@@ -58,7 +58,6 @@ class _MyAppState extends State<MyApp> {
       publicKey: 'cxtp_3EBvvOiDcFwgutlSBX507UsXvrSQts',
       ignoreUrls: [],
       ignoreErrors: [],
-      customDomainUrl: 'https://ingress.staging.rum-ingress-coralogix.com',
       labels: {'item': 'playstation 5', 'itemPrice': 1999},
       sdkSampler: 100,
       mobileVitalsFPSSamplingRate: 150,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -133,18 +133,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -173,18 +173,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.5"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -274,10 +274,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -298,10 +298,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
   web:
     dependency: transitive
     description:

--- a/lib/cx_exporter_options.dart
+++ b/lib/cx_exporter_options.dart
@@ -29,7 +29,7 @@ class CXExporterOptions {
   // Application version
   final String version;
 
-  final String? customDomainUrl;
+  final String? proxyUrl;
 
   Map<String, dynamic>? labels;
 
@@ -57,7 +57,7 @@ class CXExporterOptions {
     required this.publicKey,
     this.ignoreUrls,
     this.ignoreErrors,
-    this.customDomainUrl,
+    this.proxyUrl,
     this.labels,
     this.sdkSampler = 100,
     this.mobileVitalsFPSSamplingRate = 300,
@@ -78,7 +78,7 @@ class CXExporterOptions {
       'environment': environment,
       'application': application,
       'version': version,
-      'customDomainUrl': customDomainUrl,
+      'proxyUrl': proxyUrl,
       'labels': labels,
       'sdkSampler': sdkSampler,
       'mobileVitalsFPSSamplingRate': mobileVitalsFPSSamplingRate,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cx_flutter_plugin
 description: "The Coralogix SDK for Flutter is designed to support various Flutter targets by leveraging the numerous platforms supported by Coralogix's native SDKs."
-version: 0.0.7
+version: 0.0.8
 homepage: https://coralogix.com
 
 


### PR DESCRIPTION
This commit updates the Coralogix Android SDK to version 2.4.3 and the `desugar_jdk_libs` to 2.1.5.

Additionally, it introduces several enhancements to the Flutter plugin:
- Renames `customDomainUrl` to `proxyUrl` in `CXExporterOptions` for clarity.
- Adds support for the `STAGING` domain in `CoralogixDomainMapper`.
- Implements new methods in `IFlutterPluginManager` and `FlutterPluginManager` for:
    - `getLabels`
    - `isInitialized`
    - `getSessionId`
    - `setApplicationContext`
- Exposes these new methods through the `CxFlutterPlugin`'s method channel.
- Updates the example app to reflect the `proxyUrl` change and use the `STAGING` domain.
- Updated the flutter plugin version to 0.0.8.