### PR TITLE
Alph 2237 log level inconsistency between what flatter sdk send and what is recieved in the ingest api

### DIFF
--- a/android/src/main/kotlin/com/coralogix/flutter/plugin/manager/FlutterPluginManager.kt
+++ b/android/src/main/kotlin/com/coralogix/flutter/plugin/manager/FlutterPluginManager.kt
@@ -135,7 +135,7 @@ internal class FlutterPluginManager(private val application: Application) : IFlu
         val dataMap = logDetails["data"] as? Map<*, *>
         val data = dataMap?.toStringMap() ?: emptyMap()
 
-        val severityLevel = (logDetails["severity"] as? String)?.toIntOrNull() ?: 5
+        val severityLevel = logDetails["severity"] as? String ?: ""
         val severity = CoralogixLogSeverityMapper.map(severityLevel) ?: run {
             result.error("Failed to parse log severity")
             return

--- a/android/src/main/kotlin/com/coralogix/flutter/plugin/mappers/CoralogixLogSeverityMapper.kt
+++ b/android/src/main/kotlin/com/coralogix/flutter/plugin/mappers/CoralogixLogSeverityMapper.kt
@@ -2,15 +2,15 @@ package com.coralogix.flutter.plugin.mappers
 
 import com.coralogix.android.sdk.model.CoralogixLogSeverity
 
-object CoralogixLogSeverityMapper : IMapper<Int, CoralogixLogSeverity?> {
-    override fun map(input: Int): CoralogixLogSeverity? {
+object CoralogixLogSeverityMapper : IMapper<String, CoralogixLogSeverity?> {
+    override fun map(input: String): CoralogixLogSeverity? {
         return when (input) {
-            1 -> CoralogixLogSeverity.Debug
-            2 -> CoralogixLogSeverity.Verbose
-            3 -> CoralogixLogSeverity.Info
-            4 -> CoralogixLogSeverity.Warn
-            5 -> CoralogixLogSeverity.Error
-            6 -> CoralogixLogSeverity.Critical
+            "debug" -> CoralogixLogSeverity.Debug
+            "verbose" -> CoralogixLogSeverity.Verbose
+            "info" -> CoralogixLogSeverity.Info
+            "warn" -> CoralogixLogSeverity.Warn
+            "error" -> CoralogixLogSeverity.Error
+            "critical" -> CoralogixLogSeverity.Critical
             else -> null
         }
     }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -133,18 +133,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -173,18 +173,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.5"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -274,10 +274,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -298,10 +298,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
   web:
     dependency: transitive
     description:

--- a/ios/Classes/CxFlutterPlugin.swift
+++ b/ios/Classes/CxFlutterPlugin.swift
@@ -163,7 +163,7 @@ public class CxFlutterPlugin: NSObject, FlutterPlugin {
     private func log(call: FlutterMethodCall, result: @escaping FlutterResult) {
         guard let arguments = call.arguments as? [String: Any], !arguments.isEmpty,
             let severity = arguments["severity"] as? String,
-            let cxLogSeverity = self.from(string: severity)
+            let cxLogSeverity = self.getCoralogixLogSeverity(rawValue: severity)
         else {
             result(FlutterError(code: "4", message: "Arguments is null or empty", details: nil))
             return
@@ -208,8 +208,8 @@ public class CxFlutterPlugin: NSObject, FlutterPlugin {
         result(lables)
     }
 
-    private static func from(_ string: String) -> CoralogixLogSeverity? {
-        switch string.lowercased() {
+    private func getCoralogixLogSeverity(rawValue: String) -> CoralogixLogSeverity? {
+        switch rawValue.lowercased() {
         case "debug": return CoralogixLogSeverity.debug
         case "verbose": return CoralogixLogSeverity.verbose
         case "info": return CoralogixLogSeverity.info

--- a/ios/Classes/CxFlutterPlugin.swift
+++ b/ios/Classes/CxFlutterPlugin.swift
@@ -163,7 +163,7 @@ public class CxFlutterPlugin: NSObject, FlutterPlugin {
     private func log(call: FlutterMethodCall, result: @escaping FlutterResult) {
         guard let arguments = call.arguments as? [String: Any], !arguments.isEmpty,
             let severity = arguments["severity"] as? String,
-            let cxLogSeverity = CoralogixLogSeverity(rawValue: Int(severity) ?? 5)
+            let cxLogSeverity = self.from(string: severity)
         else {
             result(FlutterError(code: "4", message: "Arguments is null or empty", details: nil))
             return
@@ -206,6 +206,18 @@ public class CxFlutterPlugin: NSObject, FlutterPlugin {
     private func getLabels(call: FlutterMethodCall, result: @escaping FlutterResult) {
         let lables = self.coralogixRum?.getLabels()
         result(lables)
+    }
+
+    private static func from(_ string: String) -> CoralogixLogSeverity? {
+        switch string.lowercased() {
+        case "debug": return CoralogixLogSeverity.debug
+        case "verbose": return CoralogixLogSeverity.verbose
+        case "info": return CoralogixLogSeverity.info
+        case "warn": return CoralogixLogSeverity.warn
+        case "error": return CoralogixLogSeverity.error
+        case "critical": return CoralogixLogSeverity.critical
+        default: return nil
+        }
     }
 
     private func instrumentationType(from string: String) -> CoralogixExporterOptions

--- a/lib/cx_flutter_plugin_method_channel.dart
+++ b/lib/cx_flutter_plugin_method_channel.dart
@@ -72,7 +72,8 @@ class MethodChannelCxFlutterPlugin extends CxFlutterPluginPlatform {
       CxLogSeverity severity, String message, Map<String, dynamic> data) async {
     try {
       final arguments = {
-        'severity': severity.index.toString(),
+        // on our backend the severity list starts at 1, but we start at 0
+        'severity': (severity.index + 1).toString(),
         'message': message,
         'data': data,
       };

--- a/lib/cx_flutter_plugin_method_channel.dart
+++ b/lib/cx_flutter_plugin_method_channel.dart
@@ -72,8 +72,7 @@ class MethodChannelCxFlutterPlugin extends CxFlutterPluginPlatform {
       CxLogSeverity severity, String message, Map<String, dynamic> data) async {
     try {
       final arguments = {
-        // on our backend the severity list starts at 1, but we start at 0
-        'severity': (severity.index + 1).toString(),
+        'severity': severity.name,
         'message': message,
         'data': data,
       };

--- a/lib/cx_types.dart
+++ b/lib/cx_types.dart
@@ -29,17 +29,17 @@ enum EventSource {
 }
 
 enum CxLogSeverity {
-  @JsonValue(0)
-  debug,
   @JsonValue(1)
-  verbose,
+  debug,
   @JsonValue(2)
-  info,
+  verbose,
   @JsonValue(3)
-  warn,
+  info,
   @JsonValue(4)
-  error,
+  warn,
   @JsonValue(5)
+  error,
+  @JsonValue(6)
   critical,
 }
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated log severity levels to start from 1, shifting all levels accordingly and adding a new highest severity level, "critical."
  - Changed log severity handling to use severity names instead of numeric indices for improved clarity and consistency across platforms.
  - Enhanced error handling for invalid severity values by validating severity strings before processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->