### PR TITLE
feat(android): Add placeholder for sendCxSpanData

### DIFF
--- a/android/src/main/kotlin/com/coralogix/flutter/plugin/CxFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/coralogix/flutter/plugin/CxFlutterPlugin.kt
@@ -40,6 +40,7 @@ class CxFlutterPlugin: FlutterPlugin, MethodCallHandler {
             IS_INITIALIZED -> pluginManager.isInitialized(result)
             GET_SESSION_ID -> pluginManager.getSessionId(result)
             SET_APPLICATION_CONTEXT -> pluginManager.setApplicationContext(call, result)
+            SEND_CX_SPAN_DATA -> pluginManager.sendCxSpanData(call, result)
             else -> result.notImplemented()
         }
     }
@@ -63,5 +64,6 @@ class CxFlutterPlugin: FlutterPlugin, MethodCallHandler {
         private const val IS_INITIALIZED = "isInitialized"
         private const val GET_SESSION_ID = "getSessionId"
         private const val SET_APPLICATION_CONTEXT = "setApplicationContext"
+        private const val SEND_CX_SPAN_DATA = "sendCxSpanData"
     }
 }

--- a/android/src/main/kotlin/com/coralogix/flutter/plugin/manager/FlutterPluginManager.kt
+++ b/android/src/main/kotlin/com/coralogix/flutter/plugin/manager/FlutterPluginManager.kt
@@ -1,6 +1,7 @@
 package com.coralogix.flutter.plugin.manager
 
 import android.app.Application
+import android.util.Log
 import com.coralogix.android.sdk.CoralogixRum
 import com.coralogix.android.sdk.internal.features.instrumentations.network.NetworkRequestDetails
 import com.coralogix.android.sdk.model.CoralogixLogSeverity
@@ -207,6 +208,11 @@ internal class FlutterPluginManager(private val application: Application) : IFlu
         val applicationVersion = applicationContextDetails["applicationVersion"] ?: ""
 
         CoralogixRum.setApplicationContext(applicationName, applicationVersion)
+        result.success()
+    }
+
+    override fun sendCxSpanData(call: MethodCall, result: MethodChannel.Result) {
+        Log.d("FlutterPluginManager", "sendCxSpanData is not yet implemented in Android")
         result.success()
     }
 

--- a/android/src/main/kotlin/com/coralogix/flutter/plugin/manager/IFlutterPluginManager.kt
+++ b/android/src/main/kotlin/com/coralogix/flutter/plugin/manager/IFlutterPluginManager.kt
@@ -16,4 +16,5 @@ internal interface IFlutterPluginManager {
     fun isInitialized(result: Result)
     fun getSessionId(result: Result)
     fun setApplicationContext(call: MethodCall, result: Result)
+    fun sendCxSpanData(call: MethodCall, result: Result)
 }


### PR DESCRIPTION
This commit introduces a placeholder implementation for the `sendCxSpanData` method in the Android part of the plugin.

Currently, it logs that the feature is not yet implemented and returns success. This sets up the method channel for future implementation.