### PR TITLE
fix: Change network request duration to int and update example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,3 +91,10 @@ Release Date: June 17, 2025
 
 Native Android SDK upgraded to 2.4.41
 Native iOS SDK upgraded to 1.0.23
+
+## 0.0.11
+Version 0.0.11
+Release Date: June 22, 2025
+
+* Bug fixes
+Native iOS SDK upgraded to 1.0.24

--- a/android/src/main/kotlin/com/coralogix/flutter/plugin/manager/FlutterPluginManager.kt
+++ b/android/src/main/kotlin/com/coralogix/flutter/plugin/manager/FlutterPluginManager.kt
@@ -106,8 +106,8 @@ internal class FlutterPluginManager(
             fragments = networkRequestDetailsMap["fragments"] as? String ?: "",
             host = networkRequestDetailsMap["host"] as? String ?: "",
             schema = networkRequestDetailsMap["schema"] as? String ?: "",
-            duration = (networkRequestDetailsMap["duration"] as? Int)?.toLong() ?: 0L,
-            responseContentLength = (networkRequestDetailsMap["http_response_body_size"] as? Int)?.toLong() ?: 0L,
+            duration = (networkRequestDetailsMap["duration"] as? Number)?.toLong() ?: 0L,
+            responseContentLength = (networkRequestDetailsMap["http_response_body_size"] as? Number)?.toLong() ?: 0L,
             severity = severity
         )
 

--- a/android/src/main/kotlin/com/coralogix/flutter/plugin/manager/FlutterPluginManager.kt
+++ b/android/src/main/kotlin/com/coralogix/flutter/plugin/manager/FlutterPluginManager.kt
@@ -106,8 +106,8 @@ internal class FlutterPluginManager(
             fragments = networkRequestDetailsMap["fragments"] as? String ?: "",
             host = networkRequestDetailsMap["host"] as? String ?: "",
             schema = networkRequestDetailsMap["schema"] as? String ?: "",
-            duration = networkRequestDetailsMap["duration"] as? Long ?: 0L,
-            responseContentLength = networkRequestDetailsMap["http_response_body_size"] as? Long ?: 0L,
+            duration = (networkRequestDetailsMap["duration"] as? Int)?.toLong() ?: 0L,
+            responseContentLength = (networkRequestDetailsMap["http_response_body_size"] as? Int)?.toLong() ?: 0L,
             severity = severity
         )
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -30,7 +30,8 @@ flutter_ios_podfile_setup
 # Use this for running from local Coralogix
 # pod 'Coralogix', :path => '../../../cx-ios-sdk'
 # pod 'CoralogixInternal', :path => '../../../cx-ios-sdk'  # assuming it's in the same folder
-# pod 'Coralogix', :git => 'https://github.com/coralogix/cx-ios-sdk', :branch => 'alph-2304-cold-warm-fps-anr'
+# pod 'Coralogix', :git => 'https://github.com/coralogix/cx-ios-sdk', :branch => 'branch_name'
+# pod 'CoralogixInternal', :git => 'https://github.com/coralogix/cx-ios-sdk.git', :branch => 'branch_name'
 
 target 'Runner' do
   use_frameworks!

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - Coralogix (1.0.23):
-    - CoralogixInternal (= 1.0.23)
+  - Coralogix (1.0.24):
+    - CoralogixInternal (= 1.0.24)
     - PLCrashReporter (~> 1.11.1)
-  - CoralogixInternal (1.0.23)
-  - cx_flutter_plugin (0.0.8):
-    - Coralogix (= 1.0.23)
+  - CoralogixInternal (1.0.24)
+  - cx_flutter_plugin (0.0.11):
+    - Coralogix (= 1.0.24)
     - Flutter
   - Flutter (1.0.0)
   - integration_test (0.0.1):
@@ -31,13 +31,13 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
 
 SPEC CHECKSUMS:
-  Coralogix: 0f8a89d1f366a114974a337c8aef45761591a7e2
-  CoralogixInternal: 700cfacad027e64e8d63933cf5370b6dc6656eaa
-  cx_flutter_plugin: a8a580612c7d6af2d443f79a39f6208d18297d03
+  Coralogix: 8cda6b18acc4221eee0229f6db2cb961ecfc4899
+  CoralogixInternal: 9d385720dae517e4736cb15a68e3b82824c77d0b
+  cx_flutter_plugin: c98cef853d00174387136e7dca0658d7becff558
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: d5929033778cc4991a187e4e1a85396fa4f59b3a
   PLCrashReporter: 97cef386c199b54662e744d1a62c19f7bfe08e90
 
-PODFILE CHECKSUM: 14cbd23de2d1ae2ec91a22577beabb3569671ded
+PODFILE CHECKSUM: bd67c98682467243157eb49eaad116dd7cb6d7f8
 
 COCOAPODS: 1.16.2

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:cx_flutter_plugin/cx_instrumentation_type.dart';
 import 'package:cx_flutter_plugin/cx_types.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:http/http.dart' as http;
 import 'package:http/io_client.dart';
 
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -280,23 +281,34 @@ Future<void> isInitialized() async {
 }
 
 Future<void> sendNetworkRequest(String url) async {
-  final client = await createCxHttpClientWithProxy(); // ✅ await here
-
-  try {
-    final response = await client.get(
-      Uri.parse(url),
-      headers: {
+  final client = CxHttpClient(http.Client());
+  await client.get(
+    Uri.parse(url),
+    headers: {
       'Accept': 'application/json',
       'User-Agent': 'FlutterApp/1.0', // Many APIs require this!
-      },
+    },
   );
-
-  } catch (e) {
-    debugPrint('Request error: $e');
-  } finally {
-    client.close();
-  }
 }
+
+// Future<void> sendNetworkRequest(String url) async {
+//   final client = await createCxHttpClientWithProxy(); // ✅ await here
+//
+//   try {
+//     final response = await client.get(
+//       Uri.parse(url),
+//       headers: {
+//       'Accept': 'application/json',
+//       'User-Agent': 'FlutterApp/1.0', // Many APIs require this!
+//       },
+//   );
+//
+//   } catch (e) {
+//     debugPrint('Request error: $e');
+//   } finally {
+//     client.close();
+//   }
+// }
 
 Future<CxHttpClient> createCxHttpClientWithProxy() async {
   // Use 10.0.2.2 for Android emulator, localhost for iOS simulator

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -50,7 +50,7 @@ class _MyAppState extends State<MyApp> {
       userMetadata: {'role': 'admin'},
     );
 
-    var coralogixDomain = CXDomain.staging;
+    var coralogixDomain = CXDomain.eu2;
 
     var options = CXExporterOptions(
       coralogixDomain: coralogixDomain,
@@ -64,13 +64,15 @@ class _MyAppState extends State<MyApp> {
       labels: {'item': 'playstation 5', 'itemPrice': 1999},
       sdkSampler: 100,
       mobileVitalsFPSSamplingRate: 150,
-      instrumentations: { CXInstrumentationType.anr.value: true,
-                          CXInstrumentationType.custom.value: true,
-                          CXInstrumentationType.errors.value: true,
-                          CXInstrumentationType.lifeCycle.value: true,
-                          CXInstrumentationType.mobileVitals.value: true,
-                          CXInstrumentationType.network.value: true,
-                          CXInstrumentationType.userActions.value: true},
+      instrumentations: {
+        CXInstrumentationType.anr.value: true,
+        CXInstrumentationType.custom.value: true,
+        CXInstrumentationType.errors.value: true,
+        CXInstrumentationType.lifeCycle.value: true,
+        CXInstrumentationType.mobileVitals.value: true,
+        CXInstrumentationType.network.value: true,
+        CXInstrumentationType.userActions.value: true,
+      },
       collectIPData: true,
       enableSwizzling: false,
       debug: true,
@@ -95,93 +97,93 @@ class _MyAppState extends State<MyApp> {
         body: Align(
           alignment: Alignment.center,
           child: SingleChildScrollView(
-          child: Column(
-            children: [
-            TooltipButton(
-              onPressed: () => sendNetworkRequest('https://coralogix.com'),
-              text: 'Send Network Request',
-              buttonTitle: 'Send Successed Network Request',
-            ),
-            TooltipButton(
-              onPressed: () => sendNetworkRequest('https://coralogix.com/404'),
-              text: 'Send Failure Network Request',
-              buttonTitle: 'Send Failure Network Request',
-            ),
-            TooltipButton(
-              onPressed: () => sendUserContext(),
-              text: 'Set User Context',
-              buttonTitle: 'Set User Context',
-            ),
-            TooltipButton(
-              onPressed: () => setLabels(),
-              text: 'Set Labels',
-              buttonTitle: 'Set Labels',
-            ),
-            TooltipButton(
-              onPressed: () => sdkShutdown(),
-              text: 'Sdk shutdown',
-              buttonTitle: 'Sdk shutdown',
-            ),
-            TooltipButton(
-              onPressed: () => reportError(),
-              text: 'Dart: Report Error',
-              buttonTitle: 'Dart: Report Error',
-            ),
-            TooltipButton(
-              onPressed: () => sendLog(),
-              text: 'Dart: Send Log',
-              buttonTitle: 'Dart: Send Log',
-            ),
-            TooltipButton(
-              onPressed: () => navigateToNewScreen(context),
-              text: 'Navigate To NewScreen',
-              buttonTitle: 'Navigate To NewScreen',
-            ),
-            TooltipButton(
-              onPressed: () {
-                assert(false, 'assert failure');
-              },
-              text: 'Dart: Assert Exception',
-              buttonTitle: 'Dart: Assert Exception',
-            ),
-            TooltipButton(
-              onPressed: () => throwTryCatchInDart(),
-              text: 'Dart: Throw Exception',
-              buttonTitle: 'Dart: Throw Exception',
-            ),
-            TooltipButton(
-              onPressed: () => throwEcexpotionInDart(),
-              text: 'Dart: throw onPressed',
-              buttonTitle: 'Dart: throw onPressed',
-            ),
-            TooltipButton(
-              onPressed: () => platformExecute('fatalError'),
-              text: 'Swift fatalError',
-              buttonTitle: 'Swift fatalError',
-            ),
-            TooltipButton(
-              onPressed: () => getLabels(),
-              text: 'Get Lables',
-              buttonTitle: 'Get Lables',
-            ),
-            TooltipButton(
-              onPressed: () => isInitialized(),
-              text: 'Is Initialized',
-              buttonTitle: 'Is Initialized',
-            ),
-            TooltipButton(
-              onPressed: () => getSessionId(),
-              text: 'Get Session Id',
-              buttonTitle: 'Get Session Id',
-            ),
-            TooltipButton(
-              onPressed: () => setApplicationContext(),
-              text: 'Set Application Context',
-              buttonTitle: 'Set Application Context',
-            ),
-          ]),
+            child: Column(children: [
+              TooltipButton(
+                onPressed: () => sendNetworkRequest('https://coralogix.com'),
+                text: 'Send Network Request',
+                buttonTitle: 'Send Successed Network Request',
+              ),
+              TooltipButton(
+                onPressed: () =>
+                    sendNetworkRequest('https://coralogix.com/404'),
+                text: 'Send Failure Network Request',
+                buttonTitle: 'Send Failure Network Request',
+              ),
+              TooltipButton(
+                onPressed: () => sendUserContext(),
+                text: 'Set User Context',
+                buttonTitle: 'Set User Context',
+              ),
+              TooltipButton(
+                onPressed: () => setLabels(),
+                text: 'Set Labels',
+                buttonTitle: 'Set Labels',
+              ),
+              TooltipButton(
+                onPressed: () => sdkShutdown(),
+                text: 'Sdk shutdown',
+                buttonTitle: 'Sdk shutdown',
+              ),
+              TooltipButton(
+                onPressed: () => reportError(),
+                text: 'Dart: Report Error',
+                buttonTitle: 'Dart: Report Error',
+              ),
+              TooltipButton(
+                onPressed: () => sendLog(),
+                text: 'Dart: Send Log',
+                buttonTitle: 'Dart: Send Log',
+              ),
+              TooltipButton(
+                onPressed: () => navigateToNewScreen(context),
+                text: 'Navigate To NewScreen',
+                buttonTitle: 'Navigate To NewScreen',
+              ),
+              TooltipButton(
+                onPressed: () {
+                  assert(false, 'assert failure');
+                },
+                text: 'Dart: Assert Exception',
+                buttonTitle: 'Dart: Assert Exception',
+              ),
+              TooltipButton(
+                onPressed: () => throwTryCatchInDart(),
+                text: 'Dart: Throw Exception',
+                buttonTitle: 'Dart: Throw Exception',
+              ),
+              TooltipButton(
+                onPressed: () => throwEcexpotionInDart(),
+                text: 'Dart: throw onPressed',
+                buttonTitle: 'Dart: throw onPressed',
+              ),
+              TooltipButton(
+                onPressed: () => platformExecute('fatalError'),
+                text: 'Swift fatalError',
+                buttonTitle: 'Swift fatalError',
+              ),
+              TooltipButton(
+                onPressed: () => getLabels(),
+                text: 'Get Lables',
+                buttonTitle: 'Get Lables',
+              ),
+              TooltipButton(
+                onPressed: () => isInitialized(),
+                text: 'Is Initialized',
+                buttonTitle: 'Is Initialized',
+              ),
+              TooltipButton(
+                onPressed: () => getSessionId(),
+                text: 'Get Session Id',
+                buttonTitle: 'Get Session Id',
+              ),
+              TooltipButton(
+                onPressed: () => setApplicationContext(),
+                text: 'Set Application Context',
+                buttonTitle: 'Set Application Context',
+              ),
+            ]),
+          ),
         ),
-      ),
       ),
     );
   }
@@ -310,6 +312,8 @@ class NewScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    CxFlutterPlugin.setView('New Screen');
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('New Screen'),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -310,17 +310,17 @@ Future<void> sendNetworkRequest(String url) async {
 //   }
 // }
 
-Future<CxHttpClient> createCxHttpClientWithProxy() async {
-  // Use 10.0.2.2 for Android emulator, localhost for iOS simulator
-  final proxy = Platform.isAndroid ? '10.0.2.2:9090' : 'localhost:9090';
+// Future<CxHttpClient> createCxHttpClientWithProxy() async {
+//   // Use 10.0.2.2 for Android emulator, localhost for iOS simulator
+//   final proxy = Platform.isAndroid ? '10.0.2.2:9090' : 'localhost:9090';
 
-  final httpClient = HttpClient();
-  httpClient.findProxy = (uri) => "PROXY $proxy";
-  httpClient.badCertificateCallback = (X509Certificate cert, String host, int port) => true;
-  final ioClient = IOClient(httpClient);
+//   final httpClient = HttpClient();
+//   httpClient.findProxy = (uri) => "PROXY $proxy";
+//   httpClient.badCertificateCallback = (X509Certificate cert, String host, int port) => true;
+//   final ioClient = IOClient(httpClient);
 
-  return CxHttpClient(ioClient);
-}
+//   return CxHttpClient(ioClient);
+// }
 
 class TooltipButton extends StatelessWidget {
   final String text;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,7 +8,6 @@ import 'package:cx_flutter_plugin/cx_instrumentation_type.dart';
 import 'package:cx_flutter_plugin/cx_types.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:http/http.dart' as http;
 import 'package:http/io_client.dart';
 
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -53,7 +52,7 @@ class _MyAppState extends State<MyApp> {
       userMetadata: {'role': 'admin'},
     );
 
-    var coralogixDomain = CXDomain.eu2;
+    var coralogixDomain = CXDomain.staging;
 
     var options = CXExporterOptions(
       coralogixDomain: coralogixDomain,
@@ -102,7 +101,7 @@ class _MyAppState extends State<MyApp> {
           child: SingleChildScrollView(
             child: Column(children: [
               TooltipButton(
-                onPressed: () => sendNetworkRequest('https://reqres.in/api/users/2'),
+                onPressed: () => sendNetworkRequest('https://jsonplaceholder.typicode.com/posts/'),
                 text: 'Send Network Request',
                 buttonTitle: 'Send Successed Network Request',
               ),
@@ -292,10 +291,8 @@ Future<void> sendNetworkRequest(String url) async {
       },
   );
 
-    print('Status: ${response.statusCode}');
-    print('Body: ${response.body}');
   } catch (e) {
-    print('Request error: $e');
+    debugPrint('Request error: $e');
   } finally {
     client.close();
   }

--- a/ios/cx_flutter_plugin.podspec
+++ b/ios/cx_flutter_plugin.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'cx_flutter_plugin'
-  s.version          = '0.0.8'
+  s.version          = '0.0.11'
   s.summary          = 'Coralogix Flutter plugin.'
   s.description      = <<-DESC
 Coralogix Flutter plugin.
@@ -20,7 +20,7 @@ Coralogix Flutter plugin.
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
 
-  s.dependency 'Coralogix', '1.0.23'
+  s.dependency 'Coralogix', '1.0.24'
 
   s.ios.deployment_target = '13.0'
   s.static_framework = true

--- a/lib/cx_types.dart
+++ b/lib/cx_types.dart
@@ -323,7 +323,7 @@ class NetworkRequestContext {
   @JsonKey(name: 'response_content_length')
   String? responseContentLength;
 
-  double? duration;
+  int? duration;
 
   NetworkRequestContext({
     required this.method,
@@ -350,8 +350,8 @@ class NetworkRequestContext {
       statusText: json['status_text'] as String?,
       responseContentLength: json['response_content_length'] as String?,
       duration: json['duration'] is String
-          ? double.tryParse(json['duration'] as String)
-          : (json['duration'] as num?)?.toDouble(),
+          ? int.tryParse(json['duration'] as String) ?? 0
+          : json['duration'] as int? ?? 0,
     );
   }
 

--- a/lib/cx_types.dart
+++ b/lib/cx_types.dart
@@ -323,7 +323,7 @@ class NetworkRequestContext {
   @JsonKey(name: 'response_content_length')
   String? responseContentLength;
 
-  int? duration;
+  int duration;
 
   NetworkRequestContext({
     required this.method,
@@ -334,7 +334,7 @@ class NetworkRequestContext {
     this.schema,
     this.statusText,
     this.responseContentLength,
-    this.duration,
+    this.duration = 0,
   });
 
   factory NetworkRequestContext.fromJson(Map<String, dynamic> json) {

--- a/lib/cx_types.dart
+++ b/lib/cx_types.dart
@@ -20,17 +20,6 @@ enum CoralogixEventType {
   lifeCycle,
 }
 
-enum EventSource {
-  console,
-  fetch,
-  code,
-  unhandledRejection,
-  @JsonValue('mobile')
-  mobile,
-  @JsonValue('mobile-vitals')
-  mobileVitals,
-}
-
 enum CxLogSeverity {
   @JsonValue(1)
   debug,
@@ -206,14 +195,12 @@ class DeviceContext {
 @JsonSerializable()
 class EventContext {
   final CoralogixEventType type;
-  @JsonKey(includeIfNull: true)
-  final EventSource? source;
+  
   @JsonKey(includeIfNull: true)
   final CxLogSeverity? severity;
 
   EventContext({
     required this.type,
-    this.source,
     this.severity,
   });
 
@@ -304,6 +291,41 @@ class LogContext {
 
   Map<String, dynamic> toJson() => _$LogContextToJson(this);
 }
+
+class InteractionContext {
+    @JsonKey(name: 'element_id')
+    String? elementId;
+      
+    @JsonKey(name: 'event_name')
+    String? eventName;
+
+    final Map<String, dynamic>? attributes;
+
+    InteractionContext({
+      this.elementId,
+      this.eventName,
+      this.attributes,
+    });
+
+    factory InteractionContext.fromJson(Map<String, dynamic> json) {
+      return InteractionContext(
+        elementId: json['element_id'] as String?,
+        eventName: json['event_name'] as String?,
+        attributes: json['attributes'] != null 
+            ? Map<String, dynamic>.from(json['attributes'] as Map)
+            : null,
+      );
+    }
+
+     Map<String, dynamic> toJson() {
+     return {
+        'element_id': elementId,
+        'event_name': eventName,
+        'attributes': attributes,
+      };
+    }
+}
+    
 
 @JsonSerializable()
 class NetworkRequestContext {
@@ -607,6 +629,8 @@ class CxRumEvent {
   ViewContext? viewContext;
   EventContext? eventContext;
   ErrorContext? errorContext;
+  @JsonKey(name: 'interaction_context')
+  InteractionContext? interactionContext;
   LogContext? logContext;
   NetworkRequestContext? networkRequestContext;
   SnapshotContext? snapshotContext;
@@ -630,6 +654,7 @@ class CxRumEvent {
     this.viewContext,
     this.eventContext,
     this.errorContext,
+    this.interactionContext,
     this.logContext,
     this.networkRequestContext,
     this.snapshotContext,
@@ -676,6 +701,10 @@ class CxRumEvent {
           ? null
           : ErrorContext.fromJson(
               json['error_context'] as Map<String, dynamic>),
+      interactionContext: json['interaction_context'] == null
+          ? null
+          : InteractionContext.fromJson(
+              json['interaction_context'] as Map<String, dynamic>),
       logContext: json['log_context'] == null
           ? null
           : LogContext.fromJson(json['log_context'] as Map<String, dynamic>),
@@ -718,6 +747,7 @@ class CxRumEvent {
       'view_context': viewContext?.toJson(),
       'event_context': eventContext?.toJson(),
       'error_context': errorContext?.toJson(),
+      'interaction_context': interactionContext?.toJson(),
       'log_context': logContext?.toJson(),
       'network_request_context': networkRequestContext?.toJson(),
       'snapshot_context': snapshotContext?.toJson(),
@@ -746,6 +776,7 @@ class EditableCxRumEvent extends CxRumEvent {
     super.viewContext,
     super.eventContext,
     super.errorContext,
+    super.interactionContext,
     super.logContext,
     super.networkRequestContext,
     super.snapshotContext,
@@ -801,6 +832,11 @@ class EditableCxRumEvent extends CxRumEvent {
               ? ErrorContext.fromJson(
                   Map<String, dynamic>.from(json['error_context']))
               : null,
+      interactionContext:
+        json.containsKey('interaction_context') && json['interaction_context'] != null
+              ? InteractionContext.fromJson(
+                  Map<String, dynamic>.from(json['interaction_context']))
+              : null,
       logContext: json.containsKey('log_context') && json['log_context'] != null
           ? LogContext.fromJson(Map<String, dynamic>.from(json['log_context']))
           : null,
@@ -852,6 +888,7 @@ class EditableCxRumEvent extends CxRumEvent {
       'view_context': viewContext?.toJson(),
       'event_context': eventContext?.toJson(),
       'error_context': errorContext?.toJson(),
+      'interaction_context': interactionContext?.toJson(),
       'log_context': logContext?.toJson(),
       'network_request_context': networkRequestContext?.toJson(),
       'snapshot_context': snapshotContext?.toJson(),

--- a/lib/cx_types.g.dart
+++ b/lib/cx_types.g.dart
@@ -102,14 +102,12 @@ Map<String, dynamic> _$DeviceContextToJson(DeviceContext instance) =>
 
 EventContext _$EventContextFromJson(Map<String, dynamic> json) => EventContext(
       type: $enumDecode(_$CoralogixEventTypeEnumMap, json['type']),
-      source: $enumDecodeNullable(_$EventSourceEnumMap, json['source']),
       severity: $enumDecodeNullable(_$CxLogSeverityEnumMap, json['severity']),
     );
 
 Map<String, dynamic> _$EventContextToJson(EventContext instance) =>
     <String, dynamic>{
       'type': _$CoralogixEventTypeEnumMap[instance.type]!,
-      'source': _$EventSourceEnumMap[instance.source],
       'severity': _$CxLogSeverityEnumMap[instance.severity],
     };
 
@@ -125,15 +123,6 @@ const _$CoralogixEventTypeEnumMap = {
   CoralogixEventType.navigation: 'navigation',
   CoralogixEventType.mobileVitals: 'mobile-vitals',
   CoralogixEventType.lifeCycle: 'life-cycle',
-};
-
-const _$EventSourceEnumMap = {
-  EventSource.console: 'console',
-  EventSource.fetch: 'fetch',
-  EventSource.code: 'code',
-  EventSource.unhandledRejection: 'unhandledRejection',
-  EventSource.mobile: 'mobile',
-  EventSource.mobileVitals: 'mobile-vitals',
 };
 
 const _$CxLogSeverityEnumMap = {
@@ -364,6 +353,10 @@ CxRumEvent _$CxRumEventFromJson(Map<String, dynamic> json) => CxRumEvent(
       errorContext: json['errorContext'] == null
           ? null
           : ErrorContext.fromJson(json['errorContext'] as Map<String, dynamic>),
+      interactionContext: json['interaction_context'] == null
+          ? null
+          : InteractionContext.fromJson(
+              json['interaction_context'] as Map<String, dynamic>),
       logContext: json['logContext'] == null
           ? null
           : LogContext.fromJson(json['logContext'] as Map<String, dynamic>),
@@ -406,6 +399,7 @@ Map<String, dynamic> _$CxRumEventToJson(CxRumEvent instance) =>
       'viewContext': instance.viewContext,
       'eventContext': instance.eventContext,
       'errorContext': instance.errorContext,
+      'interaction_context': instance.interactionContext,
       'logContext': instance.logContext,
       'networkRequestContext': instance.networkRequestContext,
       'snapshotContext': instance.snapshotContext,
@@ -450,6 +444,10 @@ EditableCxRumEvent _$EditableCxRumEventFromJson(Map<String, dynamic> json) =>
       errorContext: json['errorContext'] == null
           ? null
           : ErrorContext.fromJson(json['errorContext'] as Map<String, dynamic>),
+      interactionContext: json['interaction_context'] == null
+          ? null
+          : InteractionContext.fromJson(
+              json['interaction_context'] as Map<String, dynamic>),
       logContext: json['logContext'] == null
           ? null
           : LogContext.fromJson(json['logContext'] as Map<String, dynamic>),
@@ -492,6 +490,7 @@ Map<String, dynamic> _$EditableCxRumEventToJson(EditableCxRumEvent instance) =>
       'viewContext': instance.viewContext,
       'eventContext': instance.eventContext,
       'errorContext': instance.errorContext,
+      'interaction_context': instance.interactionContext,
       'logContext': instance.logContext,
       'networkRequestContext': instance.networkRequestContext,
       'snapshotContext': instance.snapshotContext,

--- a/lib/cx_types.g.dart
+++ b/lib/cx_types.g.dart
@@ -210,7 +210,7 @@ NetworkRequestContext _$NetworkRequestContextFromJson(
       schema: json['schema'] as String?,
       statusText: json['status_text'] as String?,
       responseContentLength: json['response_content_length'] as String?,
-      duration: (json['duration'] as num?)?.toDouble(),
+      duration: (json['duration'] as num).toInt(),
     );
 
 Map<String, dynamic> _$NetworkRequestContextToJson(

--- a/lib/cx_types.g.dart
+++ b/lib/cx_types.g.dart
@@ -210,7 +210,7 @@ NetworkRequestContext _$NetworkRequestContextFromJson(
       schema: json['schema'] as String?,
       statusText: json['status_text'] as String?,
       responseContentLength: json['response_content_length'] as String?,
-      duration: (json['duration'] as num).toInt(),
+      duration: (json['duration'] as num?)?.toInt() ?? 0,
     );
 
 Map<String, dynamic> _$NetworkRequestContextToJson(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: cx_flutter_plugin
 description: "The Coralogix SDK for Flutter is designed to support various Flutter targets by leveraging the numerous platforms supported by Coralogix's native SDKs."
 version: 0.0.10
 homepage: https://coralogix.com
-
+publish_to: https://pub.dev
 
 environment:
   sdk: '>=3.4.1 <4.0.0'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the network request duration field to use integers instead of doubles for improved consistency.
  - Enhanced parsing logic to handle duration values correctly during data deserialization.
  - Improved type casting for network request details to accept broader numeric input types.

- **Style**
  - Reformatted widget layout and code style for improved readability.

- **New Features**
  - Added screen view tracking in the NewScreen widget for better analytics.
  - Updated network request URLs on main and new screens.
  - Introduced custom HTTP client with proxy support and enhanced request headers.
  - Added support for interaction context data in event tracking.

- **Chores**
  - Specified package publishing destination to the official Dart package repository.
  - Upgraded iOS SDK dependency to version 1.0.24.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->