### PR TITLE
Add proxyUrl support to Flutter Plugin ALPH-2291

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,3 +98,8 @@ Release Date: June 22, 2025
 
 * Bug fixes
 Native iOS SDK upgraded to 1.0.24
+
+## 0.0.12
+Version 0.0.12
+* New Feature add support for proxyUrl
+Native iOS SDK upgraded to 1.0.25

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - Coralogix (1.0.24):
-    - CoralogixInternal (= 1.0.24)
+  - Coralogix (1.0.25):
+    - CoralogixInternal (= 1.0.25)
     - PLCrashReporter (~> 1.11.1)
-  - CoralogixInternal (1.0.24)
-  - cx_flutter_plugin (0.0.11):
-    - Coralogix (= 1.0.24)
+  - CoralogixInternal (1.0.25)
+  - cx_flutter_plugin (0.0.12):
+    - Coralogix (= 1.0.25)
     - Flutter
   - Flutter (1.0.0)
   - integration_test (0.0.1):
@@ -31,9 +31,9 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
 
 SPEC CHECKSUMS:
-  Coralogix: 8cda6b18acc4221eee0229f6db2cb961ecfc4899
-  CoralogixInternal: 9d385720dae517e4736cb15a68e3b82824c77d0b
-  cx_flutter_plugin: c98cef853d00174387136e7dca0658d7becff558
+  Coralogix: 19f437acd441e9d3c8edf9052c5220e2363607e6
+  CoralogixInternal: 97e6d496dc8100660710722c2380876195d776bd
+  cx_flutter_plugin: b328ef734ad327b4f1cfdd45b563505451c3b9c3
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: d5929033778cc4991a187e4e1a85396fa4f59b3a
   PLCrashReporter: 97cef386c199b54662e744d1a62c19f7bfe08e90

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -64,6 +64,7 @@ class _MyAppState extends State<MyApp> {
       publicKey: dotenv.env['CORALOGIX_PUBLIC_KEY']!,
       ignoreUrls: [],
       ignoreErrors: [],
+      //proxyUrl: 'https:127.0.0.1:8888',
       labels: {'item': 'playstation 5', 'itemPrice': 1999},
       sdkSampler: 100,
       mobileVitalsFPSSamplingRate: 150,

--- a/ios/Classes/CxFlutterPlugin.swift
+++ b/ios/Classes/CxFlutterPlugin.swift
@@ -293,6 +293,7 @@ public class CxFlutterPlugin: NSObject, FlutterPlugin {
             instrumentations: instrumentationDict,
             collectIPData: parameter["collectIPData"] as? Bool ?? true,
             enableSwizzling: parameter["enableSwizzling"] as? Bool ?? true,
+            proxyUrl: parameter["proxyUrl"] as? String ?? nil,
             debug: parameter["debug"] as? Bool ?? false)
         return options
     }

--- a/ios/cx_flutter_plugin.podspec
+++ b/ios/cx_flutter_plugin.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'cx_flutter_plugin'
-  s.version          = '0.0.11'
+  s.version          = '0.0.12'
   s.summary          = 'Coralogix Flutter plugin.'
   s.description      = <<-DESC
 Coralogix Flutter plugin.
@@ -20,7 +20,7 @@ Coralogix Flutter plugin.
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
 
-  s.dependency 'Coralogix', '1.0.24'
+  s.dependency 'Coralogix', '1.0.25'
 
   s.ios.deployment_target = '13.0'
   s.static_framework = true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: cx_flutter_plugin
 description: "The Coralogix SDK for Flutter is designed to support various Flutter targets by leveraging the numerous platforms supported by Coralogix's native SDKs."
-version: 0.0.10
+version: 0.0.12
 homepage: https://coralogix.com
-publish_to: https://pub.dev
+# publish_to: https://pub.dev/packages/cx_flutter_plugin
 
 environment:
   sdk: '>=3.4.1 <4.0.0'


### PR DESCRIPTION
feat: Add proxyUrl support to Flutter Plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a proxy URL in the SDK options.

* **Chores**
  * Updated the iOS SDK dependency to version 1.0.25.
  * Bumped plugin version to 0.0.12.
  * Updated documentation and versioning details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->