### PR TITLE
Add trace parent in header support to flutter plugin ALPH-2296 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,4 +105,4 @@ Release Date:
 
 * New Feature add support for proxyUrl
 * New Feature traceParentInHeader (iOS Only)
-Native iOS SDK upgraded to 1.0.25
+Native iOS SDK upgraded to 1.0.26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,5 +101,8 @@ Native iOS SDK upgraded to 1.0.24
 
 ## 0.0.12
 Version 0.0.12
+Release Date:
+
 * New Feature add support for proxyUrl
+* New Feature traceParentInHeader (iOS Only)
 Native iOS SDK upgraded to 1.0.25

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -30,8 +30,8 @@ flutter_ios_podfile_setup
 # Use this for running from local Coralogix
 # pod 'Coralogix', :path => '../../../cx-ios-sdk'
 # pod 'CoralogixInternal', :path => '../../../cx-ios-sdk'  # assuming it's in the same folder
-# pod 'Coralogix', :git => 'https://github.com/coralogix/cx-ios-sdk', :branch => 'branch_name'
-# pod 'CoralogixInternal', :git => 'https://github.com/coralogix/cx-ios-sdk.git', :branch => 'branch_name'
+# pod 'Coralogix', :git => 'https://github.com/coralogix/cx-ios-sdk', :branch => ''
+# pod 'CoralogixInternal', :git => 'https://github.com/coralogix/cx-ios-sdk.git', :branch => ''
 
 target 'Runner' do
   use_frameworks!

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - Coralogix (1.0.25):
-    - CoralogixInternal (= 1.0.25)
+  - Coralogix (1.0.26):
+    - CoralogixInternal (= 1.0.26)
     - PLCrashReporter (~> 1.11.1)
-  - CoralogixInternal (1.0.25)
+  - CoralogixInternal (1.0.26)
   - cx_flutter_plugin (0.0.12):
-    - Coralogix (= 1.0.25)
+    - Coralogix (= 1.0.26)
     - Flutter
   - Flutter (1.0.0)
   - integration_test (0.0.1):
@@ -31,13 +31,13 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
 
 SPEC CHECKSUMS:
-  Coralogix: 19f437acd441e9d3c8edf9052c5220e2363607e6
-  CoralogixInternal: 97e6d496dc8100660710722c2380876195d776bd
-  cx_flutter_plugin: b328ef734ad327b4f1cfdd45b563505451c3b9c3
+  Coralogix: d309405928d875267824223be9c44e4f32549001
+  CoralogixInternal: 7a0a978acc42a7cc4cdd47b277d74368766dd55c
+  cx_flutter_plugin: 941912fde0d83c301ac12986807ab7b76ecfab72
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: d5929033778cc4991a187e4e1a85396fa4f59b3a
   PLCrashReporter: 97cef386c199b54662e744d1a62c19f7bfe08e90
 
-PODFILE CHECKSUM: bd67c98682467243157eb49eaad116dd7cb6d7f8
+PODFILE CHECKSUM: 63237c7a23745d59aecfd9b8d7a93ce962f7e0b8
 
 COCOAPODS: 1.16.2

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -79,7 +79,7 @@ class _MyAppState extends State<MyApp> {
       enableSwizzling: true,
       traceParentInHeader: { 'enable': true, 
                             'options': {
-                                'allowedTracingUrls': ['https://jsonplaceholder.typicode.com/posts/', 'a']
+                                'allowedTracingUrls': ['https://jsonplaceholder.typicode.com/posts/']
                               }
                           },
       debug: true,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:cx_flutter_plugin/cx_domain.dart';
 import 'package:cx_flutter_plugin/cx_exporter_options.dart';
@@ -8,12 +7,11 @@ import 'package:cx_flutter_plugin/cx_instrumentation_type.dart';
 import 'package:cx_flutter_plugin/cx_types.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:http/http.dart' as http;
-import 'package:http/io_client.dart';
 
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 import 'package:cx_flutter_plugin/cx_flutter_plugin.dart';
+//import 'package:http/io_client.dart';
 
 const channel = MethodChannel('example.flutter.coralogix.io');
 
@@ -69,16 +67,21 @@ class _MyAppState extends State<MyApp> {
       sdkSampler: 100,
       mobileVitalsFPSSamplingRate: 150,
       instrumentations: {
-        CXInstrumentationType.anr.value: true,
-        CXInstrumentationType.custom.value: true,
-        CXInstrumentationType.errors.value: true,
-        CXInstrumentationType.lifeCycle.value: true,
-        CXInstrumentationType.mobileVitals.value: true,
+        CXInstrumentationType.anr.value: false,
+        CXInstrumentationType.custom.value: false,
+        CXInstrumentationType.errors.value: false,
+        CXInstrumentationType.lifeCycle.value: false,
+        CXInstrumentationType.mobileVitals.value: false,
         CXInstrumentationType.network.value: true,
         CXInstrumentationType.userActions.value: true,
       },
       collectIPData: true,
-      enableSwizzling: false,
+      enableSwizzling: true,
+      traceParentInHeader: { 'enable': true, 
+                            'options': {
+                                'allowedTracingUrls': ['https://jsonplaceholder.typicode.com/posts/', 'a']
+                              }
+                          },
       debug: true,
     );
 
@@ -108,8 +111,7 @@ class _MyAppState extends State<MyApp> {
                 buttonTitle: 'Send Successed Network Request',
               ),
               TooltipButton(
-                onPressed: () =>
-                    sendNetworkRequest('https://coralogix.com/404'),
+                onPressed: () => sendNetworkRequest('https://coralogix.com/404'),
                 text: 'Send Failure Network Request',
                 buttonTitle: 'Send Failure Network Request',
               ),
@@ -282,7 +284,7 @@ Future<void> isInitialized() async {
 }
 
 Future<void> sendNetworkRequest(String url) async {
-  final client = CxHttpClient(http.Client());
+  final client = CxHttpClient();
   await client.get(
     Uri.parse(url),
     headers: {
@@ -292,24 +294,24 @@ Future<void> sendNetworkRequest(String url) async {
   );
 }
 
-// Future<void> sendNetworkRequest(String url) async {
+//  Future<void> sendNetworkRequest(String url) async {
 //   final client = await createCxHttpClientWithProxy(); // ✅ await here
-//
+
 //   try {
 //     final response = await client.get(
 //       Uri.parse(url),
 //       headers: {
-//       'Accept': 'application/json',
-//       'User-Agent': 'FlutterApp/1.0', // Many APIs require this!
+//        'Accept': 'application/json',
+//        'User-Agent': 'FlutterApp/1.0', // Many APIs require this!
 //       },
-//   );
-//
+//    );
+
 //   } catch (e) {
 //     debugPrint('Request error: $e');
 //   } finally {
 //     client.close();
 //   }
-// }
+//  }
 
 // Future<CxHttpClient> createCxHttpClientWithProxy() async {
 //   // Use 10.0.2.2 for Android emulator, localhost for iOS simulator

--- a/ios/Classes/CxFlutterPlugin.swift
+++ b/ios/Classes/CxFlutterPlugin.swift
@@ -294,6 +294,7 @@ public class CxFlutterPlugin: NSObject, FlutterPlugin {
             collectIPData: parameter["collectIPData"] as? Bool ?? true,
             enableSwizzling: parameter["enableSwizzling"] as? Bool ?? true,
             proxyUrl: parameter["proxyUrl"] as? String ?? nil,
+            traceParentInHeader: parameter["traceParentInHeader"] as? [String: Any] ?? nil,
             debug: parameter["debug"] as? Bool ?? false)
         return options
     }

--- a/ios/cx_flutter_plugin.podspec
+++ b/ios/cx_flutter_plugin.podspec
@@ -20,7 +20,7 @@ Coralogix Flutter plugin.
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
 
-  s.dependency 'Coralogix', '1.0.25'
+  s.dependency 'Coralogix', '1.0.26'
 
   s.ios.deployment_target = '13.0'
   s.static_framework = true

--- a/lib/cx_exporter_options.dart
+++ b/lib/cx_exporter_options.dart
@@ -45,11 +45,19 @@ class CXExporterOptions {
   // Determines whether the SDK should collect the user's IP address and corresponding geolocation data. Defaults to true.
   final bool collectIPData;
 
-  // Enable event access and modification before sending to Coralogix, supporting content modification, and event discarding. */
+  // Enable event access and modification before sending to Coralogix, supporting content modification, and event discarding. 
   final BeforeSendResult Function(EditableCxRumEvent event) beforeSend;
 
+  // When set to `false`, disables Coralogix's automatic method swizzling.
+  // Swizzling is used to auto-instrument various system behaviors (e.g., view controller lifecycle,
+  // app delegate events, network calls). Disabling it gives you full manual control over instrumentation.
+  //
+  // - Remark: As of the current Coralogix SDK version, `enableSwizzling = false` only disables `NSURLSession` instrumentation.
   final bool enableSwizzling;
 
+  // Add trace context propagation in headers across service boundaries
+  Map<String, dynamic>? traceParentInHeader;
+  
   CXExporterOptions({
     required this.coralogixDomain,
     this.userContext,
@@ -68,6 +76,7 @@ class CXExporterOptions {
     this.debug = false,
     this.beforeSend = _defaultBeforeSend,
     required this.enableSwizzling,
+    this.traceParentInHeader,
   });
 
   Map<String, dynamic> toMap() {
@@ -88,6 +97,7 @@ class CXExporterOptions {
       'instrumentations': instrumentations,
       'collectIPData': collectIPData,
       'enableSwizzling': enableSwizzling,
+      'traceParentInHeader': traceParentInHeader,
     };
   }
 }

--- a/lib/cx_flutter_plugin.dart
+++ b/lib/cx_flutter_plugin.dart
@@ -4,7 +4,18 @@ import 'package:cx_flutter_plugin/cx_types.dart';
 import 'cx_flutter_plugin_platform_interface.dart';
 
 class CxFlutterPlugin {
+  // Global storage for options
+  static CXExporterOptions? _globalOptions;
+
+  // Getter to access global options
+  static CXExporterOptions? get globalOptions => _globalOptions;
+
+  // Check if options are available
+  static bool get hasGlobalOptions => _globalOptions != null;
+
   static Future<String?> initSdk(CXExporterOptions options) {
+    // Save options globally for later use
+    _globalOptions = options;
     return CxFlutterPluginPlatform.instance.initSdk(options);
   }
 
@@ -32,6 +43,8 @@ class CxFlutterPlugin {
   }
 
   static Future<String?> shutdown() {
+    // Clear global options on shutdown
+    _globalOptions = null;
     return CxFlutterPluginPlatform.instance.shutdown();
   }  
 

--- a/lib/cx_http_client.dart
+++ b/lib/cx_http_client.dart
@@ -1,8 +1,8 @@
-
 import 'dart:async';
 import 'dart:convert';
-
+import 'dart:math';
 import 'package:cx_flutter_plugin/cx_flutter_plugin.dart';
+import 'package:cx_flutter_plugin/cx_utils.dart';
 import 'package:http/http.dart' as http;
 
 class CxHttpClient extends http.BaseClient {
@@ -10,11 +10,33 @@ class CxHttpClient extends http.BaseClient {
 
   CxHttpClient(this._inner);
 
+  String generateTraceParent(String traceId, String spanId) {
+    const version = '00';
+    const traceFlags = '01';
+    return '$version-$traceId-$spanId-$traceFlags';
+  }
+
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
     var stopwatch = Stopwatch()..start();
-
+     String generateHex(int length) {
+      const chars = '0123456789abcdef';
+      return List.generate(length, (_) => chars[Random().nextInt(16)]).join();
+    }
+    
+    final traceId = generateHex(32); // 16 bytes
+    final spanId = generateHex(16);  // 8 bytes
+    
+    // Get options from global storage
+    final options = CxFlutterPlugin.globalOptions;
+    final shouldAddTraceParent = options != null && Utils.shouldAddTraceParent(request.url.toString(), options);
+  
+    if (shouldAddTraceParent) { 
+      var traceparent = generateTraceParent(traceId, spanId);
+      request.headers['traceparent'] = traceparent;
+    }
     final response = await _inner.send(request);
+
     stopwatch.stop();
     var duration = stopwatch.elapsed;
 
@@ -31,6 +53,11 @@ class CxHttpClient extends http.BaseClient {
       'schema': request.url.scheme,
     };
     
+    if (shouldAddTraceParent) {
+      networkRequestContext['traceId'] = traceId;
+      networkRequestContext['spanId'] = spanId;
+    }
+
     await CxFlutterPlugin.setNetworkRequestContext(networkRequestContext);
 
     // Return the response with a new stream

--- a/lib/cx_http_client.dart
+++ b/lib/cx_http_client.dart
@@ -25,7 +25,8 @@ class CxHttpClient extends http.BaseClient {
     var stopwatch = Stopwatch()..start();
      String generateHex(int length) {
       const chars = '0123456789abcdef';
-      return List.generate(length, (_) => chars[Random().nextInt(16)]).join();
+      final random = Random.secure();
+      return List.generate(length, (_) => chars[random.nextInt(16)]).join();
     }
     
     final traceId = generateHex(32); // 16 bytes

--- a/lib/cx_http_client.dart
+++ b/lib/cx_http_client.dart
@@ -8,7 +8,11 @@ import 'package:http/http.dart' as http;
 class CxHttpClient extends http.BaseClient {
   final http.Client _inner;
 
-  CxHttpClient(this._inner);
+  // Default constructor that creates its own http.Client
+  CxHttpClient() : _inner = http.Client();
+
+  // Constructor that accepts a custom http.Client (for testing or custom configuration)
+  CxHttpClient.withClient(this._inner);
 
   String generateTraceParent(String traceId, String spanId) {
     const version = '00';
@@ -71,5 +75,11 @@ class CxHttpClient extends http.BaseClient {
       persistentConnection: response.persistentConnection,
       reasonPhrase: response.reasonPhrase,
     );
+  }
+
+  // Close the underlying http client
+  @override
+  void close() {
+    _inner.close();
   }
 }

--- a/lib/cx_utils.dart
+++ b/lib/cx_utils.dart
@@ -1,0 +1,87 @@
+import 'package:cx_flutter_plugin/cx_exporter_options.dart';
+
+// Missing classes that should be in cx_types.dart
+class TraceParentInHeader {
+  final bool enable;
+  final List<String>? allowedTracingUrls;
+
+  TraceParentInHeader({
+    required this.enable,
+    this.allowedTracingUrls,
+  });
+
+  static TraceParentInHeader params(Map<String, dynamic>? params) {
+    if (params == null) {
+      return TraceParentInHeader(enable: false);
+    }
+    
+    final enable = params['enable'] ?? false;
+    final options = params['options'] as Map<String, dynamic>?;
+    
+    List<String>? allowedTracingUrls;
+    if (options != null && options['allowedTracingUrls'] != null) {
+      allowedTracingUrls = List<String>.from(options['allowedTracingUrls']);
+    }
+    
+    return TraceParentInHeader(
+      enable: enable,
+      allowedTracingUrls: allowedTracingUrls,
+    );
+  }
+}
+
+class Global {
+  static bool isHostMatchesRegexPattern(String url, List<String> patterns) {
+    try {
+      final uri = Uri.parse(url);
+      final host = uri.host;
+      
+      for (final pattern in patterns) {
+        if (pattern.contains('*')) {
+          // Simple wildcard matching
+          final regexPattern = pattern.replaceAll('*', '.*');
+          final regex = RegExp(regexPattern);
+          if (regex.hasMatch(host)) {
+            return true;
+          }
+        } else if (host == pattern) {
+          return true;
+        }
+      }
+      return false;
+    } catch (e) {
+      return false;
+    }
+  }
+}
+
+class Utils {
+  static bool shouldAddTraceParent(String? requestURLString, CXExporterOptions options) {
+    if (requestURLString == null) {
+      return false;
+    }
+
+    final traceParentDict = options.traceParentInHeader;
+    if (traceParentDict == null) {
+      return false;
+    }
+
+    final traceParent = TraceParentInHeader.params(traceParentDict);
+
+    if (!traceParent.enable) {
+      return false;
+    }
+
+    final allowedUrls = traceParent.allowedTracingUrls;
+
+    if (allowedUrls != null && allowedUrls.isNotEmpty) {
+      if (allowedUrls.contains(requestURLString)) {
+        return true;
+      }
+
+      return Global.isHostMatchesRegexPattern(requestURLString, allowedUrls);
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for including trace context propagation headers (traceparent) in network requests on iOS, configurable via new options.
  * Introduced configuration to control which URLs receive tracing headers.
  * Exposed global access to SDK options and their presence status.

* **Improvements**
  * Updated the native iOS SDK dependency to version 1.0.26.
  * Enhanced documentation for instrumentation and configuration options.

* **Refactor**
  * Improved HTTP client to support trace context headers and proper resource cleanup.
  * Added utility classes for tracing configuration and URL pattern matching.

* **Style**
  * Cleaned up unused imports and improved code formatting in example files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->